### PR TITLE
add version number on footer

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { version } from '../../package.json'
 import GithubIcon from '@/components/icons/GithubIcon';
 import XIcon from '@/components/icons/XIcon';
 import DiscordIcon from '@/components/icons/DiscordIcon';
@@ -11,7 +12,7 @@ function Footer() {
         <div>
           Built by <span className='title'>RootstockLabs</span>
         </div>
-        <p>Copyright © { year } RootstockLabs. All rights reserved.</p>
+        <p>Copyright © { year } RootstockLabs. All rights reserved. v{ version }</p>
       </div>
       <div className='links'>
         <a href="https://rootstock.io/" target='_blank'>About RootstockLabs</a>

--- a/src/styles/_content.scss
+++ b/src/styles/_content.scss
@@ -155,11 +155,13 @@
 
 footer {
   padding: 20px;
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
   font-size: 14px;
   margin-top: 50px;
   .copyright {
+    justify-self: start;
     font-size: 14px;
     color: white;
     .title {
@@ -173,6 +175,7 @@ footer {
   }
 
   .links {
+    justify-self: center;
     display: flex;
     align-items: center;
     gap: 20px;
@@ -187,6 +190,7 @@ footer {
   }
 
   .icons {
+    justify-self: end;
     display: flex;
     align-items: center;
     gap: 20px;

--- a/src/styles/_responsive.scss
+++ b/src/styles/_responsive.scss
@@ -87,21 +87,28 @@
     }
   }
   footer {
+    display: flex;
     flex-direction: column;
+    .copyright,
+    .links,
+    .icons {
+      justify-self: unset;
+    }
     .links {
       margin: 25px 0;
       display: flex;
       flex-direction: column;
-      align-items: flex-start;
+      align-items: center;
       a {
         display: block;
-        margin: 10px 0;
+        margin: 2px 0;
       }
     }
     .icons {
       margin-top: 20px;
       display: flex;
       justify-content: space-between;
+      align-self: stretch;
     }
   }
 }


### PR DESCRIPTION
This pull request updates the footer component to display the app version and improves the layout and responsiveness of the footer section. The main changes include showing the version number, switching the footer layout from flex to CSS grid for better alignment, and enhancing mobile responsiveness.

**Footer Functionality:**

* The footer now displays the app version by importing `version` from `package.json` and rendering it next to the copyright statement. [[1]](diffhunk://#diff-febe472312c34362d6340a54dd876572b5ef8731d37a0d895c9b6b1f2ead8a8eR2) [[2]](diffhunk://#diff-febe472312c34362d6340a54dd876572b5ef8731d37a0d895c9b6b1f2ead8a8eL14-R15)

**Footer Layout Improvements:**

* The footer's layout is changed from a flexbox to a CSS grid, providing better alignment of the copyright, links, and icons sections. Grid properties like `grid-template-columns` and `justify-self` are used for precise positioning. [[1]](diffhunk://#diff-78eeb020dd2815f435eedbd67943111e708205d7f879dd0d4156a9eb4a5c1265L158-R164) [[2]](diffhunk://#diff-78eeb020dd2815f435eedbd67943111e708205d7f879dd0d4156a9eb4a5c1265R178) [[3]](diffhunk://#diff-78eeb020dd2815f435eedbd67943111e708205d7f879dd0d4156a9eb4a5c1265R193)

**Responsive Design Enhancements:**

* On smaller screens, the footer switches back to a columnar flex layout, and alignment adjustments are made for child elements to ensure a clean, stacked appearance. Margins and spacing are also tweaked for better mobile presentation.