### PR TITLE
add startup logs

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,9 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    return;
+  }
+
+  const { logStartup } = await import('@/utils/logger');
+  const { getStartupContext } = await import('@/utils/startup-context');
+  logStartup(getStartupContext());
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -60,4 +60,8 @@ export function logFaucetError(
   logger.error({ event, err, ...fields }, event);
 }
 
+export function logStartup(fields: Record<string, unknown> = {}): void {
+  logger.info({ event: 'startup', ...fields }, 'startup');
+}
+
 export default logger;

--- a/src/utils/startup-context.ts
+++ b/src/utils/startup-context.ts
@@ -1,0 +1,35 @@
+import { version as appVersion } from '../../package.json';
+import nextPkg from 'next/package.json';
+
+function rpcHost(rpcUrl: string | undefined): string | undefined {
+  if (!rpcUrl) return undefined;
+  try {
+    return new URL(rpcUrl).host;
+  } catch {
+    return 'invalid';
+  }
+}
+
+export function getStartupContext() {
+  const port = process.env.PORT ?? '3000';
+  const hostname = process.env.HOSTNAME ?? '0.0.0.0';
+
+  return {
+    event: 'startup' as const,
+    version: appVersion,
+    nodeVersion: process.version,
+    nextVersion: nextPkg.version,
+    nodeEnv: process.env.NODE_ENV ?? 'development',
+    runtime: process.env.NEXT_RUNTIME ?? 'nodejs',
+    port: Number(port),
+    hostname,
+    listenUrl: `http://${hostname}:${port}`,
+    logLevel: process.env.LOG_LEVEL ?? 'info',
+    rskNodeHost: rpcHost(process.env.RSK_NODE),
+    faucetAddress: process.env.FAUCET_ADDRESS,
+    filterByIp: process.env.FILTER_BY_IP === 'true',
+    timerLimitMs: Number(process.env.TIMER_LIMIT) || undefined,
+    valueToDispense: Number(process.env.VALUE_TO_DISPENSE) || undefined,
+    promoValueToDispense: Number(process.env.PROMO_VALUE_TO_DISPENSE) || undefined,
+  };
+}


### PR DESCRIPTION
This pull request adds structured startup logging to the application, enabling more informative logs when the server starts. The changes introduce a new utility for collecting startup context and a new logging function, and ensure that startup information is not logged in edge runtime environments.

**Startup Logging Enhancements:**

- Added a new `getStartupContext` utility in `src/utils/startup-context.ts` to collect and structure relevant environment and configuration details, such as app version, node version, runtime, port, and important environment variables.
- Introduced a `logStartup` function in `src/utils/logger.ts` to log startup events with the collected context.
- Created a `register` function in `src/instrumentation.ts` that logs the startup context using `logStartup`, but skips logging when running in the edge runtime environment.