### PR TITLE
pin node:25-alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a lighter Node.js Alpine image
-FROM node:25-alpine AS base
+FROM node:25-alpine@sha256:bdf2cca6fe3dabd014ea60163eca3f0f7015fbd5c7ee1b0e9ccb4ced6eb02ef4 AS base
 
 # Install dependencies only when needed
 FROM base AS deps


### PR DESCRIPTION
This pull request makes a minor update to the `Dockerfile` by pinning the Node.js base image to a specific digest. This change ensures more reliable and reproducible builds by locking the image version.

* Pin the `node:25-alpine` base image to a specific SHA256 digest for improved build reproducibility.